### PR TITLE
feat: compact mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ set -g @tmux2k-theme 'onedark'
 # to show icons only
 set -g @tmux2k-icons-only true
 
+# to enable compact window tab size
+set -g @tmux2k-compact-windows true
+
 # to customize colors
 set -g @tmux2k-text '#cdcdcd' # change text to white
 set -g @tmux2k-bg-main '#ffffff' # change bg to white

--- a/scripts/tmux2k.sh
+++ b/scripts/tmux2k.sh
@@ -17,6 +17,7 @@ IFS=' ' read -r -a lplugins <<<"$(get_tmux_option '@tmux2k-left-plugins' 'git cp
 IFS=' ' read -r -a rplugins <<<"$(get_tmux_option '@tmux2k-right-plugins' 'battery network time')"
 theme=$(get_tmux_option "@tmux2k-theme" 'default')
 icons_only=$(get_tmux_option "@tmux2k-icons-only" false)
+compact=$(get_tmux_option "@tmux2k-compact-windows" false)
 
 text=$(get_tmux_option "@tmux2k-text" '#282a36')
 bg_main=$(get_tmux_option "@tmux2k-bg-main" '#15152a')
@@ -203,6 +204,11 @@ window_list() {
     wbg=${!colors[0]}
     wfg=${!colors[1]}
 
+    spacer=" "
+    if $compact; then
+        spacer=""
+    fi
+
     if $show_flags; then
         flags="#{?window_flags,#[fg=${light_red}]#{window_flags},}"
         current_flags="#{?window_flags,#[fg=${light_green}]#{window_flags},}"
@@ -210,17 +216,17 @@ window_list() {
 
     if $show_powerline; then
         tmux set-window-option -g window-status-current-format \
-            "#[fg=${wfg},bg=${wbg}]${wl_sep}#[bg=${wfg}]${current_flags}#[fg=${wbg}] #I:#W #[fg=${wfg},bg=${wbg}]${wr_sep}"
+            "#[fg=${wfg},bg=${wbg}]${wl_sep}#[bg=${wfg}]${current_flags}#[fg=${wbg}]${spacer}#I:#W${spacer}#[fg=${wfg},bg=${wbg}]${wr_sep}"
         tmux set-window-option -g window-status-format \
-            "#[fg=${bg_alt},bg=${wbg}]${wl_sep}#[bg=${bg_alt}]${flags}#[fg=${white}] #I:#W #[fg=${bg_alt},bg=${wbg}]${wr_sep}"
+            "#[fg=${bg_alt},bg=${wbg}]${wl_sep}#[bg=${bg_alt}]${flags}#[fg=${white}]${spacer}#I:#W${spacer}#[fg=${bg_alt},bg=${wbg}]${wr_sep}"
     else
-        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}] #I:#W ${current_flags} "
-        tmux set-window-option -g window-status-format "#[fg=${white},bg=${bg_alt}] #I:#W ${flags} "
+        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}] #I:#W${spacer}${current_flags} "
+        tmux set-window-option -g window-status-format "#[fg=${white},bg=${bg_alt}] #I:#W${spacer}${flags} "
     fi
 
     if $icons_only; then
-        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}] #I:#W "
-        tmux set-window-option -g window-status-format "#[fg=${white},bg=${wfg}] #I:#W "
+        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}]${spacer}#I:#W${spacer}"
+        tmux set-window-option -g window-status-format "#[fg=${white},bg=${wfg}]${spacer}#I:#W${spacer}"
     fi
 }
 


### PR DESCRIPTION
## What

- [x] Addresses feature request https://github.com/2KAbhishek/tmux2k/issues/13, to allow for a more compact set of window tabs in the status bar

## How

Adds an option to enable compact tabs via `@tmux2k-compact-windows` which sets a `spacer` value with either a space ` ` or empty `​`.

The spacer value is used on either side of the window tab text.

## Why

- [x] I want to add the compact mode feature so you can fit more windows in the status bar

## Screenshots (If applicable)

See https://github.com/2KAbhishek/tmux2k/issues/13
