### PR TITLE
Add rudimentary support for olimorris/tmux-pomodoro-plus tmux plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ set -g @tmux2k-yellow '#f8c800' # change yellow color
 - `time`: Show current time and date
 - `weather`: Show weather information
 - `window`: tmux window list
+- `pomodoro`: Shows the `#{pomodoro_status}` of the [tmux-pomodoro-plus](https://github.com/olimorris/tmux-pomodoro-plus) plugin (if installed)
 
 To use plugins:
 

--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [ -z "$TMUX" ]; then
+    echo "No tmux session."
+    exit 1
+fi
+
+# Check for olimorris/tmux-pomodoro-plus scripts
+POMODORO_SCRIPT="$HOME/.tmux/plugins/tmux-pomodoro-plus/scripts/pomodoro.sh"
+POMODORO_HELPER="$HOME/.tmux/plugins/tmux-pomodoro-plus/scripts/helpers.sh"
+
+if [ -f "$POMODORO_SCRIPT" ]; then
+    . "$POMODORO_SCRIPT"
+    . "$POMODORO_HELPER"
+fi
+
+main() {
+    pomodoro_status="$(pomodoro_status)"
+    RATE=$(get_tmux_option "@tmux2k-ping-rate" 5)
+    sleep "$RATE"
+}
+
+main

--- a/scripts/tmux2k.sh
+++ b/scripts/tmux2k.sh
@@ -48,6 +48,7 @@ declare -A plugin_colors=(
     ["weather"]="yellow text"
     ["time"]="light_blue text"
     ["window"]="bg_main blue"
+    ["pomodoro"]="bg_main green"
 )
 
 get_plugin_colors() {
@@ -163,6 +164,7 @@ set_theme() {
             ["weather"]="text yellow"
             ["time"]="text light_blue"
             ["window"]="blue bg_main"
+            ["pomodoro"]="text bg_main"
         )
     fi
 }


### PR DESCRIPTION
## What

Adds rudimentary support for [olimorris/tmux-pomodoro-plus](https://github.com/olimorris/tmux-pomodoro-plus) tmux plugin.

## How

What code changes were made to accomplish it?

- Added the `pomodoro.sh` file
- Modify the `README.md` file

## Why

- [x] I want to add a new feature

## Screenshots (If applicable)
![image](https://github.com/user-attachments/assets/c129d07d-0e91-41e7-b892-a0e450e5d96a)


## Notes
Ideally there should be a general purpose module that would allow one to insert native or plugin-added status messages like `#{pomodoro_status}` in this case.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
