### PR TITLE
feat: support custom time format to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ set -g @tmux2k-show-fahrenheit false
 # 24 hour time
 set -g @tmux2k-military-time true
 
+# Fully Custom Time format. Accepts any time format
+# that can be passed to `date`.
+set -g @tmux2k-time-format "%F %R"
+
 # network interface to watch
 set -g @tmux2k-network-name "wlo1"
 ```

--- a/scripts/time.sh
+++ b/scripts/time.sh
@@ -7,6 +7,7 @@ source "$current_dir"/utils.sh
 show_military=$(get_tmux_option "@tmux2k-military-time" false)
 show_timezone=$(get_tmux_option "@tmux2k-show-timezone" false)
 show_day_month=$(get_tmux_option "@tmux2k-day-month" false)
+time_format=$(get_tmux_option "@tmux2k-time-format" "")
 
 get_timezone() {
     if $show_timezone; then
@@ -29,6 +30,8 @@ main() {
         date +" %a %m/%d %R ${timezone}"
     elif $show_day_month; then
         date +" %a %b %d %I:%M %p ${timezone}"
+    elif [ -n "$time_format" ]; then
+        date +" ${time_format} ${timezone}"
     else
         date +" %a %I:%M %p ${timezone}"
     fi


### PR DESCRIPTION
Rather than come up with a named time format for everything users might prefer let's add some flexibility to just pass through a format directly to `date`.

## What

What does this pull request accomplish?

- [x] Add support for customize time format

## How

What code changes were made to accomplish it?

- Add `@tmux2k-time-format` option and corresponding code to support it

## Why

- [x] I want a custom time format but don't think others would want it and think flexibility would be preferred.
