### PR TITLE
feat: change some default icons/text

### DIFF
--- a/scripts/cpu.sh
+++ b/scripts/cpu.sh
@@ -41,7 +41,7 @@ main() {
     if [ "$cpu_load" = true ]; then
         echo "$(get_load)"
     else
-        cpu_label=$(get_tmux_option "@tmux2k-cpu-usage-label" "")
+        cpu_label=$(get_tmux_option "@tmux2k-cpu-usage-label" "")
         cpu_percent=$(get_percent)
         echo "$cpu_label $cpu_percent"
     fi

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -11,7 +11,7 @@ get_ssid() {
         if [ -n "$SSID" ]; then
             printf '%s' " $SSID"
         else
-            echo '󰈀 Ethernet'
+            echo '󰈀'
         fi
         ;;
 

--- a/scripts/ram.sh
+++ b/scripts/ram.sh
@@ -37,7 +37,7 @@ get_percent() {
 
 main() {
     RATE=$(get_tmux_option "@tmux2k-refresh-rate" 5)
-    ram_label=$(get_tmux_option "@tmux2k-ram-usage-label" "")
+    ram_label=$(get_tmux_option "@tmux2k-ram-usage-label" "")
     ram_percent=$(get_percent)
     echo "$ram_label $ram_percent"
     sleep "$RATE"


### PR DESCRIPTION
I typically associate a revolutions per miniute meter with CPU and associate a stack of chips with something like RAM.

Additionally, the word "Ethernet" takes up a lot of space. I think the network ethernet icon can stand on its own as compared to the wifi icon.

----

Note.. This PR is meant to be more of a discussion starter rather than seriously being considered for merge. I can achieve most of this via settings, so I can customize them for myself, but think they would be beneficial for others too.
