### PR TITLE
feat: bandwidth plugin refactor and improvements

### DIFF
--- a/scripts/bandwidth.sh
+++ b/scripts/bandwidth.sh
@@ -3,8 +3,6 @@
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$current_dir"/utils.sh
 
-network_name="en0"
-
 if [[ $(uname -s) == "Darwin" ]]; then
     network_name=$(get_tmux_option "@tmux2k-network-name" "en0")
 elif [[ $(uname -s) == "Linux" ]]; then
@@ -14,8 +12,6 @@ else
     echo "Unknown operating system"
     exit 1
 fi
-
-network_name=$(get_tmux_option "@tmux2k-network-name" "en0")
 
 get_output_rate(){
     bps=$1

--- a/scripts/bandwidth.sh
+++ b/scripts/bandwidth.sh
@@ -6,7 +6,13 @@ source "$current_dir"/utils.sh
 if [[ $(uname -s) == "Darwin" ]]; then
     network_name=$(get_tmux_option "@tmux2k-network-name" "en0")
 elif [[ $(uname -s) == "Linux" ]]; then
-    network_name=$(get_tmux_option "@tmux2k-network-name" "wlo1")
+    default_network_device="wlo1"
+    if command -v ip > /dev/null; then
+        # if we have the `ip` command let's have the default
+        # be the device associated with the default route
+        default_network_device=$(ip route show default | cut -d ' ' -f 5)
+    fi
+    network_name=$(get_tmux_option "@tmux2k-network-name" "${default_network_device}")
 else
     # TODO: update this for windows
     echo "Unknown operating system"

--- a/scripts/bandwidth.sh
+++ b/scripts/bandwidth.sh
@@ -70,7 +70,7 @@ main() {
             output_upload_unit="K"
         fi
 
-        echo " $output_upload$output_upload_unit  $output_download$output_download_unit"
+        echo "${output_upload}${output_upload_unit} ${output_download}${output_download_unit}"
     done
 }
 main

--- a/scripts/bandwidth.sh
+++ b/scripts/bandwidth.sh
@@ -17,6 +17,21 @@ fi
 
 network_name=$(get_tmux_option "@tmux2k-network-name" "en0")
 
+get_output_rate(){
+    bps=$1
+    if [ "$bps" -gt 1073741824 ]; then
+        output=$(echo "$bps 1024" | awk '{printf "%4d\n", $1/($2 * $2 * $2)}')
+        output+="G"
+    elif [ "$bps" -gt 1048576 ]; then
+        output=$(echo "$bps 1024" | awk '{printf "%4d\n", $1/($2 * $2)}')
+        output+="M"
+    else
+        output=$(echo "$bps 1024" | awk '{printf "%4d\n", $1/$2}')
+        output+="K"
+    fi
+	echo "${output}"
+}
+
 main() {
     RATE=$(get_tmux_option "@tmux2k-refresh-rate" 5) # seconds
     while true; do
@@ -48,29 +63,10 @@ main() {
         total_download_bps=$(expr "$total_download_bytes" / "$RATE")
         total_upload_bps=$(expr "$total_upload_bytes" / "$RATE")
 
-        if [ "$total_download_bps" -gt 1073741824 ]; then
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2 * $2)}')
-            output_download_unit="G"
-        elif [ "$total_download_bps" -gt 1048576 ]; then
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2)}')
-            output_download_unit="M"
-        else
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/$2}')
-            output_download_unit="K"
-        fi
+        output_download=$(get_output_rate $total_download_bps)
+        output_upload=$(get_output_rate $total_upload_bps)
 
-        if [ "$total_upload_bps" -gt 1073741824 ]; then
-            output_upload=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2 * $2)}')
-            output_upload_unit="G"
-        elif [ "$total_upload_bps" -gt 1048576 ]; then
-            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2)}')
-            output_upload_unit="M"
-        else
-            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%4d\n", $1/$2}')
-            output_upload_unit="K"
-        fi
-
-        echo "${output_upload}${output_upload_unit} ${output_download}${output_download_unit}"
+        echo "${output_upload}${output_download}"
     done
 }
 main

--- a/scripts/bandwidth.sh
+++ b/scripts/bandwidth.sh
@@ -49,24 +49,24 @@ main() {
         total_upload_bps=$(expr "$total_upload_bytes" / "$RATE")
 
         if [ "$total_download_bps" -gt 1073741824 ]; then
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.1f \n", $1/($2 * $2 * $2)}')
+            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2 * $2)}')
             output_download_unit="G"
         elif [ "$total_download_bps" -gt 1048576 ]; then
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.1f \n", $1/($2 * $2)}')
+            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2)}')
             output_download_unit="M"
         else
-            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%.1f \n", $1/$2}')
+            output_download=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/$2}')
             output_download_unit="K"
         fi
 
         if [ "$total_upload_bps" -gt 1073741824 ]; then
-            output_upload=$(echo "$total_download_bps 1024" | awk '{printf "%.1f \n", $1/($2 * $2 * $2)}')
+            output_upload=$(echo "$total_download_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2 * $2)}')
             output_upload_unit="G"
         elif [ "$total_upload_bps" -gt 1048576 ]; then
-            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%.1f \n", $1/($2 * $2)}')
+            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%4d\n", $1/($2 * $2)}')
             output_upload_unit="M"
         else
-            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%.1f \n", $1/$2}')
+            output_upload=$(echo "$total_upload_bps 1024" | awk '{printf "%4d\n", $1/$2}')
             output_upload_unit="K"
         fi
 


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] feat: use @tmux2k-refresh-rate for bandwidth plugin
- [x] feat: make bandwith output consistently sized
- [x] feat: adjust bandwidth output spacing and icons
- [x] feat: bandwith: use a function for output formatting
- [x] feat: bandwidth: drop extra network_name settings
- [x] feat: bandwidth: autodetect device based on default route


## Why

- [x] I want to adjust the output and make the code easier to maintain

## Screenshots (If applicable)

This goes from:

```
󰈀 Ethernet   4.4 K  884.0 K
```

to

```
󰈀 Ethernet    1K 962K
```




