### PR TITLE
feat: make window name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ set -g @tmux2k-time-format "%F %R"
 
 # network interface to watch
 set -g @tmux2k-network-name "wlo1"
+
+# fully custom window name format.
+# see also FORMATS and STYLES sections in tmux(1)
+set -g @tmux2k-window-name-format "█ #{window_index} #{window_name}:#{b:pane_current_path}"
+
 ```
 
 #### 🪆 Add New Plugins

--- a/scripts/tmux2k.sh
+++ b/scripts/tmux2k.sh
@@ -7,6 +7,7 @@ source "$current_dir"/utils.sh
 
 show_powerline=$(get_tmux_option "@tmux2k-show-powerline" true)
 window_list_alignment=$(get_tmux_option "@tmux2k-window-list-alignment" 'absolute-centre')
+window_name_format=$(get_tmux_option "@tmux2k-window-name-format" '#I:#W')
 refresh_rate=$(get_tmux_option "@tmux2k-refresh-rate" 60)
 start_icon=$(get_tmux_option "@tmux2k-start-icon" "session")
 l_sep=$(get_tmux_option "@tmux2k-left-sep" )
@@ -246,6 +247,7 @@ window_list() {
     wfg=${!colors[1]}
 
     spacer=" "
+    window_name_format="#I:#W"
     if $compact; then
         spacer=""
     fi
@@ -257,17 +259,17 @@ window_list() {
 
     if $show_powerline; then
         tmux set-window-option -g window-status-current-format \
-            "#[fg=${wfg},bg=${wbg}]${wl_sep}#[bg=${wfg}]${current_flags}#[fg=${wbg}]${spacer}#I:#W${spacer}#[fg=${wfg},bg=${wbg}]${wr_sep}"
+            "#[fg=${wfg},bg=${wbg}]${wl_sep}#[bg=${wfg}]${current_flags}#[fg=${wbg}]${spacer}${window_name_format}${spacer}#[fg=${wfg},bg=${wbg}]${wr_sep}"
         tmux set-window-option -g window-status-format \
-            "#[fg=${bg_alt},bg=${wbg}]${wl_sep}#[bg=${bg_alt}]${flags}#[fg=${white}]${spacer}#I:#W${spacer}#[fg=${bg_alt},bg=${wbg}]${wr_sep}"
+            "#[fg=${bg_alt},bg=${wbg}]${wl_sep}#[bg=${bg_alt}]${flags}#[fg=${white}]${spacer}${window_name_format}${spacer}#[fg=${bg_alt},bg=${wbg}]${wr_sep}"
     else
-        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}] #I:#W${spacer}${current_flags} "
-        tmux set-window-option -g window-status-format "#[fg=${white},bg=${bg_alt}] #I:#W${spacer}${flags} "
+        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}] ${window_name_format}${spacer}${current_flags} "
+        tmux set-window-option -g window-status-format "#[fg=${white},bg=${bg_alt}] ${window_name_format}${spacer}${flags} "
     fi
 
     if $icons_only; then
-        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}]${spacer}#I:#W${spacer}"
-        tmux set-window-option -g window-status-format "#[fg=${white},bg=${wfg}]${spacer}#I:#W${spacer}"
+        tmux set-window-option -g window-status-current-format "#[fg=${wbg},bg=${wfg}]${spacer}${window_name_format}${spacer}"
+        tmux set-window-option -g window-status-format "#[fg=${white},bg=${wfg}]${spacer}${window_name_format}${spacer}"
     fi
 }
 

--- a/scripts/tmux2k.sh
+++ b/scripts/tmux2k.sh
@@ -247,7 +247,6 @@ window_list() {
     wfg=${!colors[1]}
 
     spacer=" "
-    window_name_format="#I:#W"
     if $compact; then
         spacer=""
     fi


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] make window name configurable

## How

What code changes were made to accomplish it?

- Extracted '#I:#W' as a variable. And made it configurable, as below:
```tmux
set -g @tmux2k-window-name-format "█ #{window_index} #{window_name}:#{b:pane_current_path}"
```

## Why

- [x] I want to use pane path as window name to make it easier to understand what I was doing in which window.

## Screenshots (If applicable)

tmux.conf:

```tmux
set -g @tmux2k-window-name-format "█ #{window_index} #{window_name}:#{b:pane_current_path}"
```

screenshots:

<img width="1681" alt="スクリーンショット 2025-01-01 14 13 13" src="https://github.com/user-attachments/assets/884b05b0-6b02-4ac1-a8ed-1efbb4fa3d3f" />

## Notes

This is my first time submitting a pull request, so I'm sorry if there's anything weird.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
