### PR TITLE
Increase accuracy or ram plugin

### DIFF
--- a/plugins/ram.sh
+++ b/plugins/ram.sh
@@ -8,8 +8,8 @@ source "$current_dir/../lib/utils.sh"
 get_percent() {
     case $(uname -s) in
     Linux)
-        total_mem=$(free -g | awk '/^Mem/ {print $2}')
-        used_mem=$(free -g | awk '/^Mem/ {print $3}')
+        total_mem=$(free -m | awk '/^Mem/ {print $2}')
+        used_mem=$(free -m | awk '/^Mem/ {print $3}')
         memory_percent=$(((used_mem * 100) / total_mem))
         normalize_padding "$memory_percent%"
         ;;


### PR DESCRIPTION
ram plugin uses free -g under linux for the source of information.
This command outputs free memory in Gb.
Changed to free -m (Mb) to increase accuracy.
