### PR TITLE
Fixed localization and space padding

### DIFF
--- a/plugins/ram.sh
+++ b/plugins/ram.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US
 
 current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$current_dir/../lib/utils.sh"
@@ -11,7 +13,7 @@ get_percent() {
         total_mem=$(free -m | awk '/^Mem/ {print $2}')
         used_mem=$(free -m | awk '/^Mem/ {print $3}')
         memory_percent=$(((used_mem * 100) / total_mem))
-        normalize_padding "$memory_percent%"
+        normalize_padding "$memory_percent%" 4
         ;;
     Darwin)
         used_mem=$(vm_stat | grep ' active\|wired ' | sed 's/[^0-9]//g' | paste -sd ' ' - | awk -v pagesize=$(pagesize) '{printf "%d\n", ($1+$2) * pagesize / 1048576}')
@@ -36,11 +38,10 @@ get_percent() {
 }
 
 main() {
-    RATE=$(get_tmux_option "@tmux2k-refresh-rate" 5)
+#    RATE=$(get_tmux_option "@tmux2k-refresh-rate" 5)
     ram_icon=$(get_tmux_option "@tmux2k-ram-icon" "")
     ram_percent=$(get_percent)
     echo "$ram_icon $ram_percent"
-    sleep "$RATE"
 }
 
 main


### PR DESCRIPTION
## Fixed localization and space padding
1. Suddenly setting LC_ALL variable is not enough in all case. So set two more variables.
2. Max len of the ram output is 4 symbols. So we should normalize spaces to 4 not 5. It still give us 1 space. One more is added in main function. But default ram icon is wide. So two spaces looking good. May be we should add this to all OS. Now linux only.
