### PR TITLE
Fix ram plugin problem with LANGUAGE when variable is set

### DIFF
--- a/plugins/ram.sh
+++ b/plugins/ram.sh
@@ -8,8 +8,8 @@ source "$current_dir/../lib/utils.sh"
 get_percent() {
     case $(uname -s) in
     Linux)
-        total_mem=$(free -m | awk '/^Mem/ {print $2}')
-        used_mem=$(free -m | awk '/^Mem/ {print $3}')
+        total_mem=$(LC_ALL=C free -m | awk '/^Mem/ {print $2}')
+        used_mem=$(LC_ALL=C free -m | awk '/^Mem/ {print $3}')
         memory_percent=$(((used_mem * 100) / total_mem))
         normalize_padding "$memory_percent%"
         ;;


### PR DESCRIPTION
## What does the PR do? (Required)

- [x] Added LC_ALL=C before free call under Linux

According to documentation user freely can set variable LANGUAGE to localize his system. This must not affect system functioning.
For GNU utils LANGUAGE variable take precedence over LC_ALL variable except LC_ALL=C
(https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable)
Issue fixed by adding LC_ALL=C before running "free"

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have followed the style guidelines of this project