### PR TITLE
Uptime2 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,35 +268,45 @@ Show current system uptime
 
 Show current system uptime
 
-- `tmux2k-uptime2-format-string`: Sets format string, default `󰀠 %D[#dd %02#hh %02#mm%D]%d[%H[#hh %02#mm%H]%h[%2#m min%h]%d]")`
-   In format string following placeholders can be used:
-   `#d` - stay for days. Can be empty.
-   `#h` - stay for hours. Can be empty.
-   `#m` - stay for minutes. Can not be empty 
-   `#H` - stay for full hours. Full hours are calculated as `days*24+hours`
-   `#M` - stay for full minutes. Full minutes are calculated as `(days*24+hours)*60+minutes`
-   `#D` - stay for fractional days. Fractional days are calculated as `days+((hours*60+minutes)/(24*60))`. Fractional days are floating point.
-   `#F` - stay for full fractional hours. Full fractional hours are calculated as (full_hours)+(minutes/60). Full fractional hours are floating point.
-   `#f` - stay for fractional hours. Fractional hours are calculated as `(hours)+(minutes/60)`. Fractional hours are floating point.
-   Each placeholder can be preceeded by printf like format specifier. Most usefull formats are:
-   `%02` - print value in width 2 with leading zero.
-   `%2`  - print value in width 2 without leading zero.
-   `%.2` - print floating point value with 2 digits after dot.
-	Examples:
-	Lets assume that uptime is 1 day 18 hours 0 minutes. Than
-	`%3#d` expands to `  1`, `%03#d` expands to `001`, `%.2#D` expands to `1.75`, `%02#m` expands to `00` 
-    One can add contitional formatting using brackets, Supported brackets include:
-    `%D[`<Content>`%D]` - <content> is diplayed only if days value is not empty. 
-    `%d[`<Content>`%d]` - <content> is diplayed only if days value is empty.
-    `%H[`<Content>`%H]` - <content> is diplayed only if hours value is not empty.
-    `%h[`<Content>`%h]` - <content> is diplayed only if hours value is empty.
-    `%<number>[`<content>`%]` - <content> is displayed in the center of field with width <number>
-    Examples:
-    Default value of format strings displays:
-    Uptime: `30 minutes` Displayed value `30 min`
-    Uptime: `1 hour, 5 minutes` Displayed value ` 1h 05m`
-    Uptime: `3 days, 1 hour, 5 minutes` Displayed value `1d 01h 05m`
-	Uptime: `5 minutes`, format string `%5[%02m%]` Displayed value: `  05 `
+- `tmux2k-uptime2-format-string`: Sets format string, default `"󰀠 %D[#dd %02#hh %02#mm%D]%d[%H[#hh %02#mm%H]%h[%2#m min%h]%d]"`
+
+In format string following placeholders can be used:
+
+-  `#d` - stay for days. Can be empty.
+-  `#h` - stay for hours. Can be empty.
+-  `#m` - stay for minutes. Can not be empty 
+-  `#H` - stay for full hours. Full hours are calculated as `days*24+hours`
+-  `#M` - stay for full minutes. Full minutes are calculated as `(days*24+hours)*60+minutes`
+-  `#D` - stay for fractional days. Fractional days are calculated as `days+((hours*60+minutes)/(24*60))`. Fractional days are floating point.
+-  `#F` - stay for full fractional hours. Full fractional hours are calculated as (full_hours)+(minutes/60). Full fractional hours are floating point.
+-  `#f` - stay for fractional hours. Fractional hours are calculated as `(hours)+(minutes/60)`. Fractional hours are floating point.
+
+Each placeholder can be preceeded by printf like format specifier. Most usefull formats are:
+
+- `%02` - print value in width 2 with leading zero.
+- `%2`  - print value in width 2 without leading zero.
+- `%.2` - print floating point value with 2 digits after dot.
+
+Examples:
+Lets assume that uptime is 1 day 18 hours 0 minutes. Than
+
+- `%3#d` expands to `  1`, `%03#d` expands to `001`, `%.2#D` expands to `1.75`, `%02#m` expands to `00` 
+
+One can add contitional formatting using brackets, Supported brackets include:
+
+- `%D[`<Content>`%D]` - <content> is diplayed only if days value is not empty. 
+- `%d[`<Content>`%d]` - <content> is diplayed only if days value is empty.
+- `%H[`<Content>`%H]` - <content> is diplayed only if hours value is not empty.
+- `%h[`<Content>`%h]` - <content> is diplayed only if hours value is empty.
+- `%<number>[`<content>`%]` - <content> is displayed in the center of field with width <number>
+
+Examples:
+Default value of format strings displays:
+
+- Uptime: `30 minutes` Displayed value `30 min`
+- Uptime: `1 hour, 5 minutes` Displayed value ` 1h 05m`
+- Uptime: `3 days, 1 hour, 5 minutes` Displayed value `1d 01h 05m`
+- Uptime: `5 minutes`, format string `%5[%02m%]` Displayed value: `  05 `
 	
 #### 🪆 Add New Plugins
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,40 @@ Show current system uptime
 
 - `tmux2k-uptime-icon`: Icon for system uptime, default: `󰀠`
 
+#### 18. `uptime2`
+
+Show current system uptime
+
+- `tmux2k-uptime2-format-string`: Sets format string, default `󰀠 %D[#dd %02#hh %02#mm%D]%d[%H[#hh %02#mm%H]%h[%2#m min%h]%d]")`
+   In format string following placeholders can be used:
+   `#d` - stay for days. Can be empty.
+   `#h` - stay for hours. Can be empty.
+   `#m` - stay for minutes. Can not be empty 
+   `#H` - stay for full hours. Full hours are calculated as `days*24+hours`
+   `#M` - stay for full minutes. Full minutes are calculated as `(days*24+hours)*60+minutes`
+   `#D` - stay for fractional days. Fractional days are calculated as `days+((hours*60+minutes)/(24*60))`. Fractional days are floating point.
+   `#F` - stay for full fractional hours. Full fractional hours are calculated as (full_hours)+(minutes/60). Full fractional hours are floating point.
+   `#f` - stay for fractional hours. Fractional hours are calculated as `(hours)+(minutes/60)`. Fractional hours are floating point.
+   Each placeholder can be preceeded by printf like format specifier. Most usefull formats are:
+   `%02` - print value in width 2 with leading zero.
+   `%2`  - print value in width 2 without leading zero.
+   `%.2` - print floating point value with 2 digits after dot.
+	Examples:
+	Lets assume that uptime is 1 day 18 hours 0 minutes. Than
+	`%3#d` expands to `  1`, `%03#d` expands to `001`, `%.2#D` expands to `1.75`, `%02#m` expands to `00` 
+    One can add contitional formatting using brackets, Supported brackets include:
+    `%D[`<Content>`%D]` - <content> is diplayed only if days value is not empty. 
+    `%d[`<Content>`%d]` - <content> is diplayed only if days value is empty.
+    `%H[`<Content>`%H]` - <content> is diplayed only if hours value is not empty.
+    `%h[`<Content>`%h]` - <content> is diplayed only if hours value is empty.
+    `%<number>[`<content>`%]` - <content> is displayed in the center of field with width <number>
+    Examples:
+    Default value of format strings displays:
+    Uptime: `30 minutes` Displayed value `30 min`
+    Uptime: `1 hour, 5 minutes` Displayed value ` 1h 05m`
+    Uptime: `3 days, 1 hour, 5 minutes` Displayed value `1d 01h 05m`
+	Uptime: `5 minutes`, format string `%5[%02m%]` Displayed value: `  05 `
+	
 #### 🪆 Add New Plugins
 
 To add a new plugin:

--- a/main.sh
+++ b/main.sh
@@ -68,6 +68,7 @@ declare -A plugin_colors=(
     ["session"]="green text"
     ["time"]="light_blue text"
     ["uptime"]="light_blue text"
+    ["uptime2"]="light_blue text"
     ["weather"]="orange text"
     ["window-list"]="black blue"
     ["custom"]="red text"

--- a/plugins/uptime2.sh
+++ b/plugins/uptime2.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$current_dir/../lib/utils.sh"
+
+export LC_ALL="en_US.UTF-8"
+
+
+fill_placeholders() {
+# Usage: fill_placeholders formatstring placeholder type value
+	result=$1
+	while [[ "$result" =~ %([^%#]*)(${2}) ]];
+	do
+		tfs="%${BASH_REMATCH[1]}$3"
+		printf -v val ${tfs} $4
+		result=${result//${BASH_REMATCH[0]}/$val}
+	done
+	result=${result//$2/$4}
+	echo -n "$result"
+}
+
+normalize_brackets() {
+# Usage: fill_placeholders formatstring
+	result=$1
+	while [[ "$result" =~ %([1-9][0-9]*)\[([^\]]*)%\] ]];
+	do
+		content="$(normalize_padding ${BASH_REMATCH[2]} ${BASH_REMATCH[1]})"
+		result=${result/"${BASH_REMATCH[0]}"/$content}
+	done
+	echo -n "$result"
+}
+
+get_uptime() {
+    uptime -p | awk '
+    {
+        for(i=1;i<NF;i++) {
+        	if($(i) ~ /^[0-9]+$/ && $(i+1) ~ /^day/) d=$(i)
+            if($(i) ~ /^[0-9]+$/ && $(i+1) ~ /^hour/) h=$(i)
+            if($(i) ~ /^[0-9]+$/ && $(i+1) ~ /^min/) m=$(i)
+        }
+        printf "%s:%s:%d:%d:%d:%f:%f:%f\n", \
+            (d?d:""), (h?h:""), (m?m:0), \
+			(d?d:0)*24+(h?h:0), ((d?d:0)*24+(h?h:0))*60+(m?m:0), \
+			(d?d:0)+((h?h:0)*60+(m?m:0))/(24*60), \
+			(h?h:0)+(m?m:0)/60, \
+			(d?d:0)*24+(h?h:0)+(m?m:0)/60
+    }'
+}
+
+main() {
+	fs=$(get_tmux_option "@tmux2k-uptime2-format-string" "󰀠 %D[#dd %02#hh %02#mm%D]%d[%H[#hh %02#mm%H]%h[%2#m min%h]%d]")
+	user_locale=$(get_tmux_option "@tmux2k-user-locale" "en_US.UTF-8")
+	export LC_ALL="$user_locale"
+
+	t_ifs=$IFS
+	IFS=":"
+	read days hours minutes fullhours fullminutes fracdays frachours fracfullhours <<< $(get_uptime)
+	IFS=$t_ifs
+
+	if [ "$days" = "" ]; then
+		fs=${fs//%D\[*%D\]/}
+		fs=${fs//%d\[/}
+		fs=${fs//%d\]/}
+		days=0
+	else
+		fs=${fs//%d\[*%d\]/}
+		fs=${fs//%D\[/}
+		fs=${fs//%D\]/}
+	fi
+	if [ "$hours" = "" ]; then
+		fs=${fs//%H\[*%H\]/} 
+		fs=${fs//%h\[/}
+		fs=${fs//%h\]/}
+		hours=0
+	else
+		fs=${fs//%h\[*%h\]/}
+		fs=${fs//%H\[/}
+		fs=${fs//%H\]/}
+	fi
+	fs=$(fill_placeholders "$fs" "#d" "d" $days)
+	fs=$(fill_placeholders "$fs" "#h" "d" $hours)
+	fs=$(fill_placeholders "$fs" "#m" "d" $minutes)
+	fs=$(fill_placeholders "$fs" "#H" "d" $fullhours)      # full hours (days*24+hours)
+	fs=$(fill_placeholders "$fs" "#M" "d" $fullminutes)    # full minutes ((days*24+hours)*60+minutes)
+	fs=$(fill_placeholders "$fs" "#D" "f" $fracdays)       # fractional days  days+((hours*60+minutes)/(24*60))
+	fs=$(fill_placeholders "$fs" "#F" "f" $fracfullhours)  # full fractional hours (full hours)+(minutes/60)
+	fs=$(fill_placeholders "$fs" "#f" "f" $frachours)      # fractional hours (hours)+(minutes/60)
+
+	fs=$(normalize_brackets "$fs")
+
+	echo -n "$fs"
+}
+
+main


### PR DESCRIPTION
## What does the PR do? (Required)

- [x] Added uptime2 plugin

uptime2 plugin offers very flexible configuration for displaying uptime. Only configuration option is format-string.
Localization is supported with tmux2k-wide user-locale option

I think this PR is subject to discuss. Please look at it when you have time.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project
