### PR TITLE
Change cwd icon option from ram to cwd

### DIFF
--- a/plugins/cwd.sh
+++ b/plugins/cwd.sh
@@ -42,7 +42,7 @@ main() {
     # Change '/home/user' to '~'
     cwd="${path/"$HOME"/'~'}"
     truncated_cwd=$(truncate_path "$cwd")
-    cwd_icon=$(get_tmux_option "@tmux2k-ram-icon" "")
+    cwd_icon=$(get_tmux_option "@tmux2k-cwd-icon" "")
 
     echo "$cwd_icon $truncated_cwd"
 }


### PR DESCRIPTION
This pull request makes a small update to the `plugins/cwd.sh` plugin by correcting the tmux option name used to retrieve the current working directory icon.

* The tmux option variable in the `main()` function was changed from `@tmux2k-ram-icon` to `@tmux2k-cwd-icon` to accurately reflect its purpose.