### PR TITLE
feat: cwd plugin has new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Show CPU temperature
 Show current working directory
 
 - `tmux2k-cwd-icon`: Icon for directory, default: ``
+- `tmux2k-cwd-length`: Maximum path length before truncation, default: `20`
+- `tmux2k-cwd-min-depth`: Minimum directory depth before mid-truncation, default: `4`
+- `tmux2k-cwd-prefix-chars`: Characters to keep from each directory name when truncating, default: `2`
 
 #### 6. `git`
 


### PR DESCRIPTION
## What does the PR do? (Required)

Add new cwd options

- @tmux2k-cwd-length (default: 20) - max path length
- @tmux2k-cwd-min-depth (default: 4) - min depth for mid-truncation
- @tmux2k-cwd-prefix-chars (default: 2) - chars kept per directory

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [/] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

Please include relevant screenshots, recordings, or logs to support your changes.
