### PR TITLE
fix: cache aur_count

### DIFF
--- a/plugins/updates.sh
+++ b/plugins/updates.sh
@@ -38,8 +38,12 @@ get_arch_updates() {
         repo_count="$(pacman -Qu --quiet 2>/dev/null | wc -l || echo 0)"
     fi
 
+    CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tmux2k_yay_updates"
     if command -v yay >/dev/null 2>&1; then
-        aur_count="$(yay -Qua --quiet 2>/dev/null | wc -l || echo 0)"
+      if [ ! -f "$CACHE" ] || [ $(( $(date +%s) - $(stat -c %Y "$CACHE") )) -gt 300 ]; then
+        yay -Qua --quiet 2>/dev/null | wc -l > "$CACHE.tmp" && mv "$CACHE.tmp" "$CACHE"
+      fi
+      aur_count=$(cat "$CACHE" 2>/dev/null || echo 0)
     fi
 
     repo_count="$(trim "$repo_count")"


### PR DESCRIPTION
When using plugins like tmux-resurrect and it open lots of sessions at once, we risk hitting AUR rate limits. Cache aur_count for 300 seconds

## What does the PR do? (Required)

- [x] Add caching to the update counter for AUR (aur_count)

Include information that will reviewers understand the changes better, now or in future.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

After restoring 15 sessions, I was met with 
```bash
yay -Qua
 -> 1 error occurred:
        * status 429: Rate limit reached
```
I have nothing else that queries yay automatically.
