### PR TITLE
feat: add terraform icon to mise plugin

### DIFF
--- a/plugins/mise.sh
+++ b/plugins/mise.sh
@@ -38,6 +38,7 @@ get_language_icon() {
         nim) echo "" ;;
         deno) echo "" ;;
         bun) echo "" ;;
+        terraform) echo "󱁢" ;;
         usage) echo "" ;;
         *) echo "$tool" ;;
     esac


### PR DESCRIPTION
## What

Adds a Terraform icon to the `mise` plugin's language icon map.

- Icon: `󱁢` (Nerd Fonts `nf-md-terraform`, `U+F1062`)
- Shown when `terraform` is an active tool in `mise current`

## Why

Previously the plugin fell back to printing the literal tool name `terraform`, which takes up a lot of status bar space compared to other tools that have icons.