### PR TITLE
feat: support per-plugin refresh rate via `@tmux2k-<plugin>-refresh-rate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,12 @@ set -g @tmux2k-right-plugins "battery network time"
 # control refresh rate of status bar plugins that display dynamic information
 set -g @tmux2k-refresh-rate 5
 
+# override the refresh rate for a specific plugin (in seconds)
+# its output is cached and re-computed only after this many seconds,
+# useful for expensive plugins, e.g. ones that hit network APIs
+set -g @tmux2k-[plugin-name]-refresh-rate 300
+set -g @tmux2k-github-refresh-rate 300 # poll the GitHub API every 5 minutes only
+
 # to customize plugin colors
 set -g @tmux2k-[plugin-name]-colors "[background] [foreground]"
 set -g @tmux2k-cpu-colors "red black" # set cpu plugin bg to red, fg to black

--- a/lib/run_plugin.sh
+++ b/lib/run_plugin.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Runs a plugin script, honoring an optional per-plugin refresh rate:
+#     set -g @tmux2k-<plugin>-refresh-rate 300
+# When set, the plugin's output is cached and the script is only re-executed
+# after that many seconds. When unset, the plugin runs on every
+# status-interval tick (@tmux2k-refresh-rate), as before.
+#
+# Usage: run_plugin.sh <plugin> [script-path]
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$current_dir/utils.sh"
+
+plugin="$1"
+script="${2:-$current_dir/../plugins/$plugin.sh}"
+
+refresh_rate=$(get_tmux_option "@tmux2k-${plugin}-refresh-rate" "")
+
+if ! [[ "$refresh_rate" =~ ^[0-9]+$ ]]; then
+    exec "$script"
+fi
+
+get_mtime() {
+    local mtime
+    mtime=$(stat -f %m "$1" 2>/dev/null) # BSD/macOS
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=$(stat -c %Y "$1" 2>/dev/null) # GNU/Linux
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+    echo "$mtime"
+}
+
+cache_dir="${TMPDIR:-/tmp}/tmux2k-cache"
+cache_file="$cache_dir/$plugin"
+mkdir -p "$cache_dir"
+
+now=$(date +%s)
+if [ -f "$cache_file" ] && [ $((now - $(get_mtime "$cache_file"))) -lt "$refresh_rate" ]; then
+    cat "$cache_file"
+    exit 0
+fi
+
+"$script" >"$cache_file"
+cat "$cache_file"

--- a/main.sh
+++ b/main.sh
@@ -281,10 +281,10 @@ status_bar() {
     for plugin_index in "${!plugins[@]}"; do
         plugin="${plugins[$plugin_index]}"
         IFS=' ' read -r -a colors <<<"$(get_plugin_colors "$plugin")"
-        script="#($current_dir/plugins/$plugin.sh)"
+        script="#($current_dir/lib/run_plugin.sh $plugin)"
 
         if [[ "$plugin" =~ ^group([0-9]+)$ ]]; then
-            script="#(GROUP_NUM=${BASH_REMATCH[1]} $current_dir/plugins/group.sh)"
+            script="#(GROUP_NUM=${BASH_REMATCH[1]} $current_dir/lib/run_plugin.sh $plugin $current_dir/plugins/group.sh)"
         fi
 
         if [ "$side" == "left" ]; then


### PR DESCRIPTION
## What

Adds an optional per-plugin refresh rate:

```bash
set -g @tmux2k-<plugin>-refresh-rate 300
```

When set, the plugin's output is cached (in `$TMPDIR/tmux2k-cache/`) and the plugin script is only re-executed after that many seconds. When unset, behavior is exactly as before: the plugin runs on every `status-interval` tick controlled by the global `@tmux2k-refresh-rate`.

## Why

Some plugins are much more expensive than a status-bar tick. The `github` plugin runs `gh api notifications --paginate` on every tick — with the default 5s refresh rate and a few hundred unread notifications (~18 paginated requests per call), that's **~17,500 GitHub API requests/hour**, which permanently exhausts the account's 5,000/hour rate limit and breaks every other GitHub tool the user runs (this is how I found it 🙂). Same concern applies to `weather`, `updates`, etc.

Lowering the global `@tmux2k-refresh-rate` isn't a good fix because it slows down cheap widgets (`time`, `cpu`, `ram`) too.

## How

- New `lib/run_plugin.sh` wrapper; `main.sh` now routes plugin invocations (including `group` plugins) through it.
- The wrapper reads `@tmux2k-<plugin>-refresh-rate`; if unset or non-numeric it just `exec`s the plugin script — zero behavior change and no caching for plugins without the option.
- If set, it serves the cached output until the TTL expires, then re-runs the plugin and refreshes the cache.
- Works on macOS (BSD `stat -f %m`) and Linux (GNU `stat -c %Y`).

With `@tmux2k-github-refresh-rate 300`, the example above drops from ~17,500 to ~216 requests/hour while the status bar keeps updating every 5s.

## Testing

- `session git cwd github` left plugins on macOS/tmux 3.5: plugins without the option run every tick as before; `github` with `300` makes one API call per 5 minutes (verified by watching `gh` process spawns and `X-RateLimit-Used`).
- Cache hit path returns in ~30ms vs ~10s for the real `github` call with a large notification inbox.
- `bash -n` and `shellcheck` clean (only the same info-level SC1091 `source` note that existing scripts have).