### PR TITLE
feat: add packer icon to mise plugin

### DIFF
--- a/plugins/mise.sh
+++ b/plugins/mise.sh
@@ -39,6 +39,7 @@ get_language_icon() {
     deno) echo "" ;;
     bun) echo "" ;;
     terraform) echo "󱁢" ;;
+    packer) echo "" ;;
     usage) echo "" ;;
     *) echo "$tool" ;;
     esac


### PR DESCRIPTION
## What

Adds a Nerd Font icon for [HashiCorp Packer](https://developer.hashicorp.com/packer) to the `mise` plugin's tool icon map, next to the existing `terraform` entry.

- Glyph: `nf-dev-packer` (`U+E85C`, ) from the official Nerd Fonts glyph set

## Why

`packer` is a common tool managed via mise; without a mapping, the plugin falls back to printing the literal tool name, which is much wider than an icon and inconsistent with the other tools on the status bar.

## Testing

- `get_language_icon packer` returns the glyph; renders correctly on a patched Nerd Font (verified on macOS/tmux 3.5 with mise-managed packer).
- `bash -n` / `shellcheck` clean (no new warnings).