### PR TITLE
feat: add aws and kubectl icons to mise plugin

### DIFF
--- a/plugins/mise.sh
+++ b/plugins/mise.sh
@@ -40,6 +40,8 @@ get_language_icon() {
     bun) echo "" ;;
     terraform) echo "󱁢" ;;
     packer) echo "" ;;
+    aws | awscli | aws-cli) echo "" ;;
+    kubectl) echo "󱃾" ;;
     usage) echo "" ;;
     *) echo "$tool" ;;
     esac


### PR DESCRIPTION
## What

Adds Nerd Font icons for the [AWS CLI](https://aws.amazon.com/cli/) and [kubectl](https://kubernetes.io/docs/reference/kubectl/) to the `mise` plugin's tool icon map, next to the existing `terraform`/`packer` entries.

- AWS: `nf-dev-aws` (`U+E7AD`, ) — matched for `aws`, `awscli`, and `aws-cli`, since the mise registry exposes all three names for the same tool
- kubectl: `nf-md-kubernetes` (`U+F10FE`, 󱃾)

## Why

Both are common tools managed via mise; without a mapping, the plugin falls back to printing the literal tool name, which is much wider than an icon and inconsistent with the other tools on the status bar.

## Testing

- `get_language_icon` returns the correct glyph for `aws`, `awscli`, `aws-cli`, and `kubectl`; renders correctly on a patched Nerd Font (verified on macOS/tmux 3.5).
- `bash -n` / `shellcheck` clean (no new warnings).