### PR TITLE
Update message-style config for tmux v3.7 changes

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -242,6 +242,7 @@ set_theme() {
     bg_alt=$(get_tmux_option "@tmux2k-bg-alt" "$gray")
     message_bg=$(get_tmux_option "@tmux2k-message-bg" "$blue")
     message_fg=$(get_tmux_option "@tmux2k-message-fg" "$black")
+	message_fill=$(get_tmux_option "@tmux2k-message-fill" "$blue")
     pane_active_border=$(get_tmux_option "@tmux2k-pane-active-border" "$blue")
     pane_active_border_bg=$(get_tmux_option "@tmux2k-pane-active-border-bg" "$bg_main")
     pane_border=$(get_tmux_option "@tmux2k-pane-border" "$gray")
@@ -257,7 +258,7 @@ set_options() {
     tmux set-option -g status-right ""
 
     tmux set-option -g status-style "bg=${bg_main},fg=${text}"
-    tmux set-option -g message-style "bg=${message_bg},fg=${message_fg}"
+    tmux set-option -g message-style "bg=${message_bg},fg=${message_fg},fill=${message_fill}"
     tmux set-option -g pane-active-border-style "bg=${pane_active_border_bg},fg=${pane_active_border}"
     tmux set-option -g pane-border-style "bg=${pane_border_bg},fg=${pane_border}"
 


### PR DESCRIPTION
## What does the PR do? (Required)

Adapt to the message-style option changes in tmux version 3.7, make the `message-style` option behave the same as in older versions of tmux

In tmux v3.7, message-style option need to include "fill" in order to cover the whole width.
In previous version, this is unnecessary.


## Checklist (Required)

- [X ] I have tested the changes on my local machine
- [ ] I have added relevant documentation and tests for the changes

## Evidence (Required)

Before the change (`tmux set-option -g message-style "bg=${message_bg},fg=${message_fg}"`):
<img width="1419" height="61" alt="image" src="https://github.com/user-attachments/assets/fe82ff86-64eb-406d-9d7f-c6b4943ec273" />

After the change (`tmux set-option -g message-style "bg=${message_bg},fg=${message_fg},fill=${message_fill}"`):
<img width="1421" height="65" alt="image" src="https://github.com/user-attachments/assets/f96e6bb4-95f0-4efc-a15b-289cbe8c840a" />

Here is the change log from Tmux:
https://raw.githubusercontent.com/tmux/tmux/3.7/CHANGES