### PR TITLE
fix(weather): url-encode multi-word city names to prevent crash

### DIFF
--- a/plugins/weather.sh
+++ b/plugins/weather.sh
@@ -44,12 +44,15 @@ fetch_weather_information() {
     k) scale='&M' ;;
     *) scale='&m' ;;
     esac
-    curl -sL "wttr.in/$1?format=%C+%t$scale"
+    curl -sL "wttr.in/${1// /+}?format=%C+%t$scale"
 }
 
 forecast_unicode() {
     local condition=$1
-    weather_icon="${weather_icons[$condition]}"
+    weather_icon=""
+    if [[ -n $condition ]]; then
+        weather_icon="${weather_icons[$condition]}"
+    fi
     if [[ -n $weather_icon ]]; then
         echo "$weather_icon "
     else


### PR DESCRIPTION
Multi-word locations (e.g. "Oro Valley") broke the wttr.in request because the city was embedded in the URL unencoded. curl rejected the malformed URL and returned nothing, leaving the parsed condition as an empty string. Indexing the weather_icons associative array with an empty subscript is itself invalid in bash and crashed the script with "bad array subscript" regardless of quoting.

Replace spaces with `+` before building the request, and guard the icon lookup so any other empty condition (network failure, wttr.in outage) degrades to no icon instead of crashing.

## What does the PR do? (Required)

- [x] urlencodes city names in weather.sh so it doesn't crash when the location is multi-word

Include information that will reviewers understand the changes better, now or in future.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

Please include relevant screenshots, recordings, or logs to support your changes.
