### PR TITLE
fix: eliminate status bar flicker from periodic set-option calls

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -62,6 +62,39 @@ get_tmux_option() {
     fi
 }
 
+# Persistent per-plugin state, stored in files rather than tmux options.
+# A plugin runs inside a status #() job; using `tmux set-option` there forces a
+# full window redraw, which re-runs the #() and re-triggers the set — a redraw
+# loop that makes the status bar flicker. Files avoid that (and multiply so with
+# several clients, since a global option redraws them all).
+#
+# Prefer $XDG_RUNTIME_DIR (tmpfs, transient, wiped on reboot/logout) for this
+# short-lived state; fall back to the cache dir where it is unset (macOS,
+# non-systemd, ...). set_state mkdir -p's on every write and get_state defaults
+# on a missing file, so a wiped runtime dir just resets state — like a cold start.
+if [ -n "$XDG_RUNTIME_DIR" ] && [ -d "$XDG_RUNTIME_DIR" ]; then
+    state_dir="$XDG_RUNTIME_DIR/tmux2k/state"
+else
+    state_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux2k/state"
+fi
+
+get_state() {
+    # $1 = key, $2 = default value
+    if [ -f "$state_dir/$1" ]; then
+        cat "$state_dir/$1"
+    else
+        printf '%s' "$2"
+    fi
+}
+
+set_state() {
+    # $1 = key, $2 = value. Atomic write (temp + rename) so concurrent readers
+    # (e.g. multiple tmux clients running the same #() job) never see a torn file.
+    [ -d "$state_dir" ] || mkdir -p "$state_dir"
+    local tmp="$state_dir/.$1.$$"
+    printf '%s' "$2" > "$tmp" && mv -f "$tmp" "$state_dir/$1"
+}
+
 normalize_padding() {
     percent_len=${#1}
     max_len=${2:-4}

--- a/plugins/bandwidth.sh
+++ b/plugins/bandwidth.sh
@@ -34,9 +34,9 @@ get_output_rate() {
 main() {
     up_icon=$(get_tmux_option "@tmux2k-bandwidth-up-icon" "")
     down_icon=$(get_tmux_option "@tmux2k-bandwidth-down-icon" "")
-    previous_rx_bytes=$(get_tmux_option "@tmux2k-bandwidth-rx-bytes" "0")
-    previous_tx_bytes=$(get_tmux_option "@tmux2k-bandwidth-tx-bytes" "0")
-    previous_timestamp=$(get_tmux_option "@tmux2k-bandwidth-timestamp" "0")
+    previous_rx_bytes=$(get_state bandwidth-rx-bytes "0")
+    previous_tx_bytes=$(get_state bandwidth-tx-bytes "0")
+    previous_timestamp=$(get_state bandwidth-timestamp "0")
     current_timestamp=$(date +%s)
     output_download=""
     output_upload=""
@@ -70,8 +70,8 @@ main() {
     echo "$up_icon $output_upload $down_icon $output_download"
 
     # Set values for the next run
-    tmux set-option -g '@tmux2k-bandwidth-rx-bytes' "$current_rx_bytes"
-    tmux set-option -g '@tmux2k-bandwidth-tx-bytes' "$current_tx_bytes"
-    tmux set-option -g '@tmux2k-bandwidth-timestamp' "$current_timestamp"
+    set_state bandwidth-rx-bytes "$current_rx_bytes"
+    set_state bandwidth-tx-bytes "$current_tx_bytes"
+    set_state bandwidth-timestamp "$current_timestamp"
 }
 main

--- a/plugins/cpu.sh
+++ b/plugins/cpu.sh
@@ -44,7 +44,7 @@ get_cpu_usage() {
     if [ "$cpu_usage_average" -gt '1' ] ; then
         local -a cpu_usage_values=("$percent")
         local -a saved_values
-        IFS=' ' read -r -a saved_values <<< "$(get_tmux_option '@tmux2k-cpu-usage-values')"
+        IFS=' ' read -r -a saved_values <<< "$(get_state cpu-usage-values)"
         cpu_usage_values+=("${saved_values[@]}")
 
         # We want to get average of n=cpu_usage_average values
@@ -57,7 +57,7 @@ get_cpu_usage() {
             printf \"%.3g\", (${cpu_usage_string// /+}) / $cpu_usage_average
         }")"
 
-        tmux set -g '@tmux2k-cpu-usage-values' "$cpu_usage_string"
+        set_state cpu-usage-values "$cpu_usage_string"
     fi
 
     local output=''
@@ -66,7 +66,7 @@ get_cpu_usage() {
         color="$(pct2color "${percent}%" "$cpu_gradient")"
         output+="#[fg=${color:-default}]"
         [ "$cpu_icon_link_to" = 'usage' ] &&\
-            tmux set -g '@tmux2k-cpu-linked-color' "$color"
+            set_state cpu-linked-color "$color"
     fi
 
     if [ "$cpu_usage_decimal" = 'true' ] ; then
@@ -133,7 +133,7 @@ get_cpu_load() {
             if [ -n "$cpu_gradient" ] ; then
                 color="$(pct2color "$avg" "$cpu_gradient")"
                 [ "$cpu_icon_link_to" = "$interval" ] &&\
-                    tmux set -g '@tmux2k-cpu-linked-color' "$color"
+                    set_state cpu-linked-color "$color"
                 color="#[fg=${color:-default}]"
             fi
 
@@ -170,9 +170,9 @@ main() {
     local cpu_linked_color
     if [ -z "$cpu_icon_link_to" ] || [ -z "$cpu_gradient" ] ; then
         # Removes tmux restart requirement on reset
-        tmux set -g '@tmux2k-cpu-linked-color' ''
+        set_state cpu-linked-color ''
     else
-        cpu_linked_color="$(get_tmux_option '@tmux2k-cpu-linked-color' '')"
+        cpu_linked_color="$(get_state cpu-linked-color '')"
         [ -n "$cpu_linked_color" ] &&\
             output+="#[fg=${cpu_linked_color}]"
     fi

--- a/plugins/gpu.sh
+++ b/plugins/gpu.sh
@@ -47,7 +47,7 @@ get_gpu() {
         color="$(pct2color "${usage}%" "$gpu_gradient")"
         output+="#[fg=${color:-default}]"
         [ "$gpu_icon_link_to" = 'usage' ] &&
-            tmux set -g '@tmux2k-gpu-linked-color' "$color"
+            set_state gpu-linked-color "$color"
     fi
     output+="$(normalize_padding "${usage}%")"
     printf '%s' "$output"
@@ -59,10 +59,10 @@ main() {
     gpu_usage=$(get_gpu)
 
     if [ -z "$gpu_icon_link_to" ] || [ -z "$gpu_gradient" ]; then
-        tmux set -g '@tmux2k-gpu-linked-color' ''
+        set_state gpu-linked-color ''
     else
         local gpu_linked_color
-        gpu_linked_color="$(get_tmux_option '@tmux2k-gpu-linked-color' '')"
+        gpu_linked_color="$(get_state gpu-linked-color '')"
         [ -n "$gpu_linked_color" ] &&
             output+="#[fg=${gpu_linked_color}]"
     fi

--- a/plugins/ram.sh
+++ b/plugins/ram.sh
@@ -49,7 +49,7 @@ get_percent() {
         color="$(pct2color "${percent}%" "$ram_gradient")"
         output+="#[fg=${color:-default}]"
         [ "$ram_icon_link_to" = 'usage' ] &&
-            tmux set -g '@tmux2k-ram-linked-color' "$color"
+            set_state ram-linked-color "$color"
     fi
     output+="$(normalize_padding "${percent}%")"
     printf '%s' "$output"
@@ -61,10 +61,10 @@ main() {
     ram_percent=$(get_percent)
 
     if [ -z "$ram_icon_link_to" ] || [ -z "$ram_gradient" ]; then
-        tmux set -g '@tmux2k-ram-linked-color' ''
+        set_state ram-linked-color ''
     else
         local ram_linked_color
-        ram_linked_color="$(get_tmux_option '@tmux2k-ram-linked-color' '')"
+        ram_linked_color="$(get_state ram-linked-color '')"
         [ -n "$ram_linked_color" ] &&
             output+="#[fg=${ram_linked_color}]"
     fi


### PR DESCRIPTION
## Problem

The status bar flickers, and the whole current window gets redrawn roughly every second.

`status-left`/`status-right` are built once at load as `#(.../plugins/<plugin>.sh)` fragments, and tmux re-runs those `#()` jobs on each `status-interval`. The problem is that several plugins persist internal state by calling `tmux set-option -g @tmux2k-*` **from inside their own body** — i.e. from within the `#()` job:

- `cpu.sh` — `@tmux2k-cpu-usage-values` (rolling-average window) and `@tmux2k-cpu-linked-color`
- `ram.sh` / `gpu.sh` — `@tmux2k-{ram,gpu}-linked-color`
- `bandwidth.sh` — `@tmux2k-bandwidth-{rx-bytes,tx-bytes,timestamp}`

Every global `set-option` forces tmux to redraw, which re-evaluates the `#()`, which calls `set-option` again — a redraw loop. It's the classic "don't call `tmux set` from within a `#()`" anti-pattern, and it's amplified with multiple attached clients, since a global option redraws them all.

The `--cache` wrapper does not address this: it only spaces out / backgrounds the re-runs, and only when a per-plugin refresh rate is configured.

## Fix

Move that state out of tmux options and into files, via two small helpers in `lib/utils.sh`:

- `get_state <key> [default]` — read a state file, or the default if absent
- `set_state <key> <value>` — atomic write (temp + `rename`) so concurrent clients never read a torn file

No plugin emits a periodic `set-option` anymore, so there is no redraw trigger and the flicker is gone. Writing a small file is also cheaper than forking a tmux client.

State is stored under `$XDG_RUNTIME_DIR/tmux2k/state` when available (tmpfs, transient, wiped on reboot/logout — appropriate for this short-lived state), falling back to `${XDG_CACHE_HOME:-$HOME/.cache}/tmux2k/state` where `$XDG_RUNTIME_DIR` is unset (macOS, non-systemd). `set_state` `mkdir -p`s on every write and `get_state` returns the default on a missing file, so a wiped runtime dir just resets state — same as a cold start.

These options were internal state only (never referenced by a tmux format `#{@...}`, not documented), so **there is no user-facing configuration change**.

## Testing

- `bash -n` on all touched files; helper unit tests (default/roundtrip/empty/array-parse, atomic write with no leftover temp files)
- Verified the subshell→parent IPC used for linked colors still works via files
- Ran `cpu.sh` / `ram.sh` / `gpu.sh` / `bandwidth.sh` against a live tmux server: correct output and colors, `bandwidth` computes the right rate over a real time gap
- Confirmed the plugins no longer touch tmux options (the `@tmux2k-bandwidth-*` option value is unchanged after a run)
- Verified all four location cases: runtime dir present, `$XDG_CACHE_HOME` fallback, `$HOME/.cache` fallback, and runtime dir set-but-missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
