### PR TITLE
perf(cpu): measure usage via /proc/stat deltas instead of top

### DIFF
--- a/plugins/cpu.sh
+++ b/plugins/cpu.sh
@@ -23,8 +23,19 @@ get_cpu_usage() {
     local percent=''
     case "$(uname -s)" in
     Linux)
-        percent="$(LC_NUMERIC=en_US.UTF-8 top -bn2 -d 0.01 | grep "Cpu(s)" | tail -1 |\
-                  sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1}')"
+        local cpu_values
+        cpu_values="$(awk '/^cpu / { print $2+$3+$4+$5+$6+$7+$8, $5+$6 }' /proc/stat)"
+        percent="$(awk -v cur="$cpu_values" -v prev="$(get_state cpu-stat-prev)" '
+            BEGIN {
+                split(cur, c); split(prev, p)
+                total = c[1] - p[1]
+                idle = c[2] - p[2]
+                if (total > 0)
+                    printf "%.1f", 100 - idle / total * 100
+                else
+                    printf "%.1f", 100 - c[2] / c[1] * 100
+            }')"
+        set_state cpu-stat-prev "$cpu_values"
         ;;
 
     Darwin)


### PR DESCRIPTION
## Description

Closes #97

The Linux `CPU Usage` plugin previously ran `top -bn2 -d 0.01`, which samples a 10ms window and includes `top`'s own execution — inflating the reported usage (the plugin made the machine look busier than it was). The alternative `top -bn1` is cheap but reports the **since-boot average**, which is stale and under-reports live load.

This PR reads `/proc/stat` instead and computes the **delta against the previous refresh**, stored in plugin state (same pattern as `bandwidth.sh`). That gives real instantaneous usage with a single cheap read and no self-inflation.

- **First run** (no previous sample): falls back to the since-boot average.
- **macOS**: unchanged — already uses a low-overhead `ps -A -o %cpu` measurement, so behavior stays consistent cross-platform.
- `@tmux2k-cpu-usage-average` smoothing is unaffected (it operates on the resulting percent).

## Verification

Tested on Linux (`bash -n` + live runs in a tmux session):

| Sample | Reported |
|--------|----------|
| 1st run (since-boot fallback) | 10.1% |
| 2nd (delta over ~1s) | 28.7% |
| 3rd (delta) | 20.3% |

These track actual load (system was ~20–22% busy during the test) instead of the stale since-boot figure.